### PR TITLE
Introduce logging verbosity

### DIFF
--- a/doc/tinyramfs.8.scd
+++ b/doc/tinyramfs.8.scd
@@ -45,6 +45,10 @@ unlocking encrypted drives, mounting needed filesystems, etc.
 
 	Look for kernel modules in <path>, instead of /lib/modules/.
 
+*-v*
+
+	Increase logging verbosity..
+
 # FILES
 
 /lib/tinyramfs/hook.d/

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -9,6 +9,29 @@ print()
     printf "%s %s\n" "${2:-">>"}" "$1"
 }
 
+print_loglevel()
+{
+    [ "$1" -gt "$loglevel" ] && return
+    prefix=""
+    case "$1" in
+        0) prefix="ERROR:" ;;
+        1) prefix="WARN:"  ;;
+        2) prefix="INFO:"  ;;
+    esac
+    print "$2" "$prefix"
+    unset prefix
+}
+
+print_warn()
+{
+    print_loglevel 1 "$1"
+}
+
+print_verbose()
+{
+    print_loglevel 2 "$1"
+}
+
 panic()
 {
     eval_hooks init.fail
@@ -108,7 +131,7 @@ copy_kmod()
         [ "$modpath" = "name:" ] && return 0
         [ "$modpath" = "(builtin)" ] && return 0
     else
-        print "missing module: $1"
+        print_verbose "missing module: $1"
         return
     fi
     [ -f "${tmpdir}/$modpath" ] && return
@@ -122,7 +145,7 @@ copy_kmod()
             fi
         done
         if [ ! -f "/lib/firmware/$firmwarefile" ]; then
-            print "missing firmware for $modname: $line"
+            print_warn "missing firmware for $modname: $line"
         else
             copy_file "/lib/firmware/$firmwarefile"
         fi

--- a/tinyramfs
+++ b/tinyramfs
@@ -14,6 +14,7 @@ usage: ${0##*/} [option]... <output>
     -l         enable local mode
     -d         enable debug mode
     -f         overwrite initramfs image
+    -v         increase logging verbosity
     -h         display this message
 EOF
 
@@ -177,15 +178,20 @@ create_image()
     print "done: $output" '+>'
 }
 
-while getopts c:k:m:ldfh opt; do case $opt in
+# 0: error
+# 1: warning
+# 2: info
+loglevel=1
+while getopts c:k:m:ldfvh opt; do case $opt in
     c) config=$OPTARG ;;
     k) kernel=$OPTARG ;;
     m) moddir=$OPTARG ;;
-    l) local=1 ;;
-    d) debug=1 ;;
-    f) force=1 ;;
-    h) usage 0 ;;
-    ?) usage 2 ;;
+    l) local=1        ;;
+    d) debug=1        ;;
+    f) force=1        ;;
+    v) loglevel=$((loglevel + 1)) ;;
+    h) usage 0        ;;
+    ?) usage 2        ;;
 esac; done
 
 shift "$((OPTIND - 1))"


### PR DESCRIPTION
Add "-v" option to increase logging verbosity. Rewrite logging in copy_kmod to silent warnings for missing modules by default.